### PR TITLE
remove line limit

### DIFF
--- a/lib/src/babs_component_settings_item.dart
+++ b/lib/src/babs_component_settings_item.dart
@@ -52,16 +52,12 @@ class SettingsItem extends StatelessWidget {
               ),
         title: Text(
           title,
-          style: titleStyle ?? TextStyle(fontWeight: FontWeight.bold),
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
+          style: titleStyle ?? TextStyle(fontWeight: FontWeight.bold)
         ),
         subtitle: (subtitle != null)
             ? Text(
                 subtitle!,
-                style: subtitleStyle ?? Theme.of(context).textTheme.bodyMedium!,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
+                style: subtitleStyle ?? Theme.of(context).textTheme.bodyMedium!
               )
             : null,
         trailing: (trailing != null) ? trailing : Icon(Icons.navigate_next),


### PR DESCRIPTION
Let the users of this library control how many lines to have when passing the String data to the widgets. 1 is simply way too strict and unnecessary, as even using 3 or more lines (in the subtitle at least) still looks quite good visually

Solves #14 