### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace "com.babacar.babstrap_settings_screen"
     compileSdkVersion 30
 
     sourceSets {


### PR DESCRIPTION
Update build.gradle to fix namespace error in newer gradlew plugin and kotlin